### PR TITLE
Allow custom locale methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ app.use(i18n(app, {
     'cookie',               //  optional detect cookie      - `Cookie: locale=zh-TW`
     'header',               //  optional detect header      - `Accept-Language: zh-CN,zh;q=0.5`
     'url',                  //  optional detect url         - `/en`
-    'tld'                   //  optional detect tld(the last domain) - `koajs.cn`
+    'tld',                  //  optional detect tld(the last domain) - `koajs.cn`
+    function() {}           //  optional custom function (will be bound to the koa context)
   ]
 }));
 

--- a/index.js
+++ b/index.js
@@ -25,9 +25,11 @@ function I18n(opts) {
   var enables = this.enables = [];
   var modes = opts.modes || [];
   modes.forEach(function (v) {
-    v = localeMethods.filter(function (t) {
-      return t.toLowerCase() === v.toLowerCase();
-    })[0];
+    if(typeof v !== 'function') {
+      v = localeMethods.filter(function (t) {
+        return t.toLowerCase() === v.toLowerCase();
+      })[0];
+    }
     if (v) {
       enables.push(v);
     }
@@ -111,11 +113,10 @@ function ial(app, opts) {
   });
 
   return function *i18nMiddleware(next) {
-    var i18n = this.i18n;
-    var enables = i18n.enables;
-    enables.some(function (key) {
-      if (i18n[SET_PREFIX + key]()) return true;
-    });
+    this.i18n.enables.some(function (key) {
+      var customLocaleMethod = typeof key === 'function' && this.i18n.setLocale(key.apply(this));
+      if (customLocaleMethod || this.i18n[SET_PREFIX + key]()) return true;
+    }.bind(this));
     yield next;
   };
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "jade": "*",
     "koa": "*",
-    "koa-compose": "*",
+    "koa-compose": "2.x",
     "koa-locale": "*",
     "koa-swig": "*",
     "koa-views": "*",

--- a/test/index.js
+++ b/test/index.js
@@ -279,4 +279,47 @@ describe('koa-i18n', function() {
         .expect(200, done);
     });
   });
+
+  describe('accepts custom function as a mode', function() {
+    var app,
+    customMode = function() {
+      return this.state.defaultLocale;
+    };
+
+    before(function () {
+      app = koa()
+
+      locale(app)
+
+      app.use(function* dummyMiddleware(next) {
+        this.state.defaultLocale = 'en';
+        yield next;
+      });
+
+      app.use(i18n(app, {
+        directory: __dirname + '/fixtures/locales',
+        locales: ['zh-CN', 'en', 'zh-tw'],
+        modes: ['cookie', customMode]
+      }))
+
+      app.use(function*(next) {
+        this.body = this.i18n.__("locales.zh-CN");
+      })
+    })
+
+    it('should be `en` locale', function() {
+      return request(app.listen())
+        .get('/')
+        .expect(/Chinese\(Simplified\)/)
+        .expect(200)
+    })
+
+    it('should be `zh-cn` locale', function() {
+      return request(app.listen())
+        .get('/')
+        .set('Cookie', 'locale=zh-cn')
+        .expect(/简体中文/)
+        .expect(200)
+    })
+  });
 });


### PR DESCRIPTION
Hi strawbrary,

We just merged the below changes to the base koa-i18n fork, but using your fuzzy-matching would be very useful for us! 
We have a use case we would like to fallback to a locale whose value is set by a previous middleware - this PR would allow the user to pass a function as one of their modes (which is executed against the current koa context).
We thought this might be useful to other people too - what do you think?
Thanks!
